### PR TITLE
Add custom paths

### DIFF
--- a/api/services/SwaggerService.js
+++ b/api/services/SwaggerService.js
@@ -1512,6 +1512,8 @@ module.exports = class SwaggerService extends Service {
         paths = this.getPathModelByIdAndRelationById(paths, config, doc, modelName, modelRelation)
       }
     }
+    
+    paths = Object.assign(paths, this.app.config.swagger.paths)
 
     return paths
   }


### PR DESCRIPTION
It would be super nice to be able to add custom paths to swagger for documenting endpoints not associated with models.  This commit should do the trick.