### PR TITLE
Automatically build custom routes

### DIFF
--- a/api/services/SwaggerService.js
+++ b/api/services/SwaggerService.js
@@ -1571,23 +1571,25 @@ module.exports = class SwaggerService extends Service {
   }
 
   getCustomRoutes(paths) {
-    let basePath = this.getBasePath(this.app.config)
-    let customRoutes = _.filter(this.app.config.routes, (route) => {
+    const basePath = this.getBasePath(this.app.config)
+    const customRoutes = _.filter(this.app.config.routes, (route) => {
       return route.path.indexOf('{model}') === -1 &&
         route.path.indexOf('{parentModel}') === -1 &&
         route.path.indexOf(basePath) >= 0 &&
         route.path.indexOf('/swagger/doc') === -1
     })
-    let routes = _.zipObject(_.map(customRoutes, (route) => {
-      var path = route.path
+    const routes = _.zipObject(_.map(customRoutes, (route) => {
+      const path = route.path
       return path.substr(basePath.length, path.length - 1)
     }), _.map(customRoutes, (route) => {
-      var response = {}
+      const response = {}
       response[_.toLower(route.method)] = {
-        description: safeAccess(route, 'config.plugins.swagger.description') ? safeAccess(route, 'config.plugins.swagger.description') : 'Description has not been provided'
+        description: safeAccess(route, 'config.plugins.swagger.description') ?
+          safeAccess(route, 'config.plugins.swagger.description') :
+          'Description has not been provided'
       }
       return response
-    }));
+    }))
     return routes
   }
 

--- a/api/services/SwaggerService.js
+++ b/api/services/SwaggerService.js
@@ -3,6 +3,8 @@
 const faker = require('faker')
 const objectPath = require('object-path')
 const inflect = require('i')()
+const _ = require('lodash')
+const safeAccess = require('safe-access')
 
 const Service = require('trails/service')
 
@@ -1563,9 +1565,32 @@ module.exports = class SwaggerService extends Service {
         paths = this.getPathModelByIdAndRelationById(paths, config, doc, modelName, modelRelation)
       }
     }
+    paths = this.getCustomRoutes(paths)
     paths = Object.assign(paths, this.app.config.swagger.paths)
     return paths
   }
+
+  getCustomRoutes(paths) {
+    let basePath = this.getBasePath(this.app.config)
+    let customRoutes = _.filter(this.app.config.routes, (route) => {
+      return route.path.indexOf('{model}') === -1 &&
+        route.path.indexOf('{parentModel}') === -1 &&
+        route.path.indexOf(basePath) >= 0 &&
+        route.path.indexOf('/swagger/doc') === -1
+    })
+    let routes = _.zipObject(_.map(customRoutes, (route) => {
+      var path = route.path
+      return path.substr(basePath.length, path.length - 1)
+    }), _.map(customRoutes, (route) => {
+      var response = {}
+      response[_.toLower(route.method)] = {
+        description: safeAccess(route, 'config.plugins.swagger.description') ? safeAccess(route, 'config.plugins.swagger.description') : 'Description has not been provided'
+      }
+      return response
+    }));
+    return routes
+  }
+
   getModelMap() {
     modelMap = []
 
@@ -1601,4 +1626,3 @@ module.exports = class SwaggerService extends Service {
 // End Swagger Doc
 
 }
-

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "eslint": "^3.13.1",
     "eslint-config-trails": "^3.0.0",
     "express": "^4.14.1",
+    "safe-access": "^0.1.0",
     "lodash": "^4.11.1",
     "mocha": "^3.2.0",
     "smokesignals": "^2.1.0",


### PR DESCRIPTION
This commit automatically figures out swagger for all endpoints.  Currently a description is the only property supported by the swagger plugin.  Additional properties will be added in the future.

```js
{
  method: [ 'GET' ],
  path: '/api/v1/default/info',
  handler: 'DefaultController.info',
  config: {
    plugins: {
      swagger: {
        description: 'I am a description'
      }
    }
  }
}
```